### PR TITLE
りんどく.rbを追加

### DIFF
--- a/docs/config/connpass.json
+++ b/docs/config/connpass.json
@@ -145,6 +145,11 @@
       "id": "kokurarb",
       "name": "Kokura.rb",
       "series_id": 12012
+    },
+    {
+      "id": "rindokurb",
+      "name": "りんどく.rb",
+      "series_id": 12225
     }
   ]
 }


### PR DESCRIPTION
https://rindokurb.connpass.com/

series_idはREADMEの手順でcurlで取得しました。
`id`と`name`をどうやって取得するかわからなかったのですが、`id`はURLから、`name`はconnpass上のグループ名にしています。

もし間違っている点がございましたら、ご指摘くださいませ。
よろしくお願いいたします。