### PR TITLE
Tweak GCF timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
             --region=asia-northeast1 \
             --memory=128Mi \
             --runtime=ruby30 \
-            --timeout=5s \
+            --timeout=60s \
             --set-env-vars=GCP_PROJECT=${GCP_PROJECT},RACK_ENV=production,SENTRY_RELEASE=${GITHUB_SHA} \
             --set-secrets=SENTRY_DSN=SENTRY_DSN:latest \
             --run-service-account=function@regional-rb-calendar-2.iam.gserviceaccount.com


### PR DESCRIPTION
GCF returns 504 error...

```
2022-09-25 20:08:42.679 JSTGET504769 B5 sGoogle-Calendar-Importer https://regional-rb-calendar-rqxbmp5cha-an.a.run.app/api/calendar/connpass.ics
The request has been terminated because it has reached the maximum request timeout. To change this limit, see https://cloud.google.com/run/docs/configuring/request-timeout
```
