### PR TITLE
Hiroshima.rbを追加

### DIFF
--- a/docs/config/connpass.json
+++ b/docs/config/connpass.json
@@ -41,6 +41,11 @@
       "series_id": 7107
     },
     {
+      "id": "hiroshimarb",
+      "name": "Hiroshima.rb",
+      "series_id": 3942
+    },
+    {
       "id":   "k-ruby",
       "name": "K-Ruby(鹿児島Rubyコミュニティ)",
       "series_id": 9032


### PR DESCRIPTION
## Hiroshima.rbを追加
https://hiroshimarb.connpass.com/

**Hiroshima.rbを追加しました**
- series_idはREADME記載のcurlで取得しました
- idはconnpassのURLから取得しました(https://hiroshimarb.connpass.com/event/271126/)
- nameはconnpassのグループ名から引用しました

```shell
❯ curl -s https://hiroshimarb.connpass.com/ | grep "https://connpass.com/series/"                                                                                                                                                                         ─╯
          <input type="hidden" name="next" value="https://connpass.com/series/3942/?gmem=1" />
```

お時間あるときにご確認いただけると幸いです 🙇 