### PR TITLE
Remove ENECHANGE

### DIFF
--- a/docs/config/connpass.json
+++ b/docs/config/connpass.json
@@ -11,11 +11,6 @@
       "series_id": 6896
     },
     {
-      "id":   "enechange-meetup",
-      "name": "ENECHANGE(Otemachi.rb)",
-      "series_id": 4321
-    },
-    {
       "id":   "fukuokarb",
       "name": "Fukuoka.rb",
       "series_id": 2538


### PR DESCRIPTION
Recently Otemachi.rb is inactive and there're business events from ENECHANGE company ( e.g. https://enechange-meetup.connpass.com/event/278223/ ) in this organization.
I think we should remove ENECHANGE org now since we don't want to advertise business events in this calendar.
We can revert this commit if Otemachi.rb gets active again.