### PR TITLE
[CVE-2023-36617] Upgrade to uri 0.12.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "icalendar"
 gem "parallel"
 gem "sentry-ruby"
 gem "sinatra"
+gem "uri", ">= 0.12.2" # for CVE-2023-36617
 
 group :test do
   gem "rack-test"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       rack-protection (= 3.0.6)
       tilt (~> 2.0)
     tilt (2.1.0)
+    uri (0.12.2)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -87,10 +88,11 @@ DEPENDENCIES
   rspec-its
   sentry-ruby
   sinatra
+  uri (>= 0.12.2)
   webmock
 
 RUBY VERSION
-   ruby 3.0.4p208
+   ruby 3.2.2p53
 
 BUNDLED WITH
    2.2.33


### PR DESCRIPTION
ref. https://www.ruby-lang.org/en/news/2023/06/29/redos-in-uri-CVE-2023-36617/