### PR TITLE
Don't call connpass API in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
           sleep 3
 
           # Check status code
-          curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/api/calendar/connpass.ics | grep "200"
           curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/api/calendar/doorkeeper.ics | grep "200"
 
           pid=$(jobs -l | grep functions-framework-ruby | awk '{print $2}')


### PR DESCRIPTION
https://github.com/sue445/regional-rb-calendar/actions/runs/9239681350/job/25419125772

Because the connpass API can only be called by a specific IP address after 2024/5/23. 
https://x.com/connpass_jp/status/1790273626400501911

IP address of regional-rb-calendar execution environment (Cloud Functions) is permitted, so there is no problem.
ref. https://github.com/sue445/regional-rb-calendar/issues/254#issuecomment-2122649659