### PR TITLE
Rename Kobe.rb to KOBE.rb

### DIFF
--- a/docs/config/doorkeeper.json
+++ b/docs/config/doorkeeper.json
@@ -30,7 +30,7 @@
     },
     {
       "id":   "koberb",
-      "name": "Kobe.rb"
+      "name": "KOBE.rb"
     },
     {
       "id":   "kyotorb",


### PR DESCRIPTION
cf. https://koberb.doorkeeper.jp/

Kobe.rb was relaunched in September 2024, and starting from Meetup # 153, it has been rebranded as KOBE.rb.

cf. https://koberb.doorkeeper.jp/events/178466