### PR TITLE
Add 出雲Ruby

### DIFF
--- a/docs/config/doorkeeper.json
+++ b/docs/config/doorkeeper.json
@@ -135,6 +135,10 @@
     {
       "id": "maebashirb",
       "name": "Maebashi.rb"
+    },
+    {
+      "id": "a8b91a9d1359e036b14668d7ad",
+      "name": "出雲Ruby"
     }
   ]
 }


### PR DESCRIPTION
出雲Ruby会議01が開催されるけれど、カレンダーにないのが気になったため。
https://a8b91a9d1359e036b14668d7ad.doorkeeper.jp/events/193709

(出雲Rubyの関係者ではないです)