### PR TITLE
Extend function timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
             --region=asia-northeast1 \
             --memory=128Mi \
             --runtime=ruby40 \
-            --timeout=15s \
+            --timeout=60s \
             --max-instances=1 \
             --set-env-vars=GCP_PROJECT=${GCP_PROJECT},RACK_ENV=production,SENTRY_RELEASE=${GITHUB_SHA} \
             --set-secrets=SENTRY_DSN=SENTRY_DSN:latest,DOORKEEPER_ACCESS_TOKEN=DOORKEEPER_ACCESS_TOKEN:latest,CONNPASS_API_KEY=CONNPASS_API_KEY:latest \


### PR DESCRIPTION
`/api/calendar/doorkeeper.ics` has timed out...

<img width="793" height="122" alt="image" src="https://github.com/user-attachments/assets/39e53504-e84a-4420-8b0e-8576932d5743" />
